### PR TITLE
API: defaults for q_score's min_quality set to Bokulich et al 2013

### DIFF
--- a/q2_quality_filter/_filter.py
+++ b/q2_quality_filter/_filter.py
@@ -51,10 +51,10 @@ def _truncate(sequence_record, position):
     return (sequence_record[0], seq, sequence_record[2], qual, qual_parsed)
 
 
-# defaults as used by the Deblur manuscript
-# (Amir et al, mSystems 2016, in press)
+# defaults as used Bokulich et al, Nature Methods 2013,
+# same as QIIME 1.9.1
 def q_score(demux: SingleLanePerSampleSingleEndFastqDirFmt,
-            min_quality: int=20,
+            min_quality: int=4,
             quality_window: int=3,
             min_length_fraction: float=0.75,
             max_ambiguous: int=0) \

--- a/q2_quality_filter/test/test_filter.py
+++ b/q2_quality_filter/test/test_filter.py
@@ -82,7 +82,7 @@ class FilterTests(TestPluginBase):
         ar = Artifact.load(self.get_data_path('numeric_ids.qza'))
         view = ar.view(SingleLanePerSampleSingleEndFastqDirFmt)
         exp_sids = {'00123', '0.4560'}
-        obs, stats = q_score(view)
+        obs, stats = q_score(view, min_quality=20)
         obs_manifest = obs.manifest.view(obs.manifest.format)
         obs_manifest = pd.read_csv(obs_manifest.open(), dtype=str, comment='#')
         obs_manifest.set_index('sample-id', inplace=True)
@@ -95,6 +95,7 @@ class FilterTests(TestPluginBase):
         ar = Artifact.load(self.get_data_path('simple.qza'))
         view = ar.view(SingleLanePerSampleSingleEndFastqDirFmt)
         obs_drop_ambig, stats = q_score(view, quality_window=2,
+                                        min_quality=20,
                                         min_length_fraction=0.25)
 
         exp_drop_ambig = ["@foo_1",


### PR DESCRIPTION
cc @gregcaporaso 

Tests which previously relied on the default value for `min_quality` were revised to use the former default of `20`.

Please make sure travis executes