### PR TITLE
Update for flake8 v3.6

### DIFF
--- a/q2_quality_filter/_filter.py
+++ b/q2_quality_filter/_filter.py
@@ -62,10 +62,11 @@ _default_params = {
 
 
 def q_score(demux: SingleLanePerSampleSingleEndFastqDirFmt,
-            min_quality: int=_default_params['min_quality'],
-            quality_window: int=_default_params['quality_window'],
-            min_length_fraction: float=_default_params['min_length_fraction'],
-            max_ambiguous: int=_default_params['max_ambiguous']) \
+            min_quality: int = _default_params['min_quality'],
+            quality_window: int = _default_params['quality_window'],
+            min_length_fraction:
+            float = _default_params['min_length_fraction'],
+            max_ambiguous: int = _default_params['max_ambiguous']) \
                   -> (SingleLanePerSampleSingleEndFastqDirFmt,
                       pd.DataFrame):
     result = SingleLanePerSampleSingleEndFastqDirFmt()
@@ -185,10 +186,11 @@ def q_score(demux: SingleLanePerSampleSingleEndFastqDirFmt,
 
 def q_score_joined(
             demux: SingleLanePerSampleSingleEndFastqDirFmt,
-            min_quality: int=_default_params['min_quality'],
-            quality_window: int=_default_params['quality_window'],
-            min_length_fraction: float=_default_params['min_length_fraction'],
-            max_ambiguous: int=_default_params['max_ambiguous']) \
+            min_quality: int = _default_params['min_quality'],
+            quality_window: int = _default_params['quality_window'],
+            min_length_fraction:
+            float = _default_params['min_length_fraction'],
+            max_ambiguous: int = _default_params['max_ambiguous']) \
                   -> (SingleLanePerSampleSingleEndFastqDirFmt,
                       pd.DataFrame):
     return q_score(demux, min_quality, quality_window,

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,5 +1,6 @@
 
 # Version: 0.18
+# flake8: noqa
 
 """The Versioneer - like a rocketeer, but for versions.
 


### PR DESCRIPTION
Minor updates for compliance with flake8 v3.6, as discussed in qiime2/qiime2#415
Note: flake8 has been disabled in versioneer.py.